### PR TITLE
Updates for handling Ansible 2.2 changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,5 @@ mlag_defaults:
   peer_link_lacp_mode: active
   peer_link_enable: true
   state: present
+
+resource_version: '2.2'

--- a/eos_module.yml
+++ b/eos_module.yml
@@ -21,6 +21,25 @@
         username: "{{ username | default(omit) }}"
       when: module == 'eos_command'
 
+    # Call the eos_config module if module is set to eos_config
+    - name: "{{ description | default('config playbook task') }}"
+      eos_config:
+        lines: "{{ lines | default(['']) }}"
+        parents: "{{ parents | default(omit) }}"
+        before: "{{ before | default(omit) }}"
+        after: "{{ after | default(omit) }}"
+        match: "{{ match | default('none')}}"
+        auth_pass: "{{ auth_pass | default(omit) }}"
+        authorize: "{{ authorize | default(omit) }}"
+        host: "{{ host | default(omit) }}"
+        password: "{{ password | default(omit) }}"
+        port: "{{ port | default(omit) }}"
+        provider: "{{ provider | default(omit) }}"
+        transport: "cli"
+        use_ssl: "{{ use_ssl | default(omit) }}"
+        username: "{{ username | default(omit) }}"
+      when: module == 'eos_config'
+
     # Call the eos_template module if module is set to eos_template
     - name: "{{ description | default('template playbook task') }}"
       eos_template:
@@ -35,4 +54,6 @@
         transport: "cli"
         use_ssl: "{{ use_ssl | default(omit) }}"
         username: "{{ username | default(omit) }}"
-      when: module == 'eos_template'
+      when: module == 'eos_template' and
+            (ansible_version.major < 2 or
+             (ansible_version.major == 2 and ansible_version.minor < 2))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+# Determine what resources we will use for running the role:
+# If using Ansible 2.1 or lower, we can use eos_template
+# If using Ansible 2.2 or higher, we must use eos_config
+# resource_version is set to 2.2 by default (since most users will be
+# on updated versions), change it if we're running 2.1 or lower.'
+- set_fact:
+    resource_version: '2.1'
+  when: ansible_version.major < 2 or
+        (ansible_version.major == 2 and ansible_version.minor < 2)
+
 - name: Gather EOS configuration
   eos_command:
     commands: 'show running-config all | exclude \.\*'
@@ -21,71 +31,6 @@
   no_log: "{{ no_log | default(true) }}"
   when: _eos_config is not defined
 
-- name: Arista MLAG (Vlan Configuration)
-  eos_template:
-    src: base_vlan.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: mlag is defined
-
-- name: Arista MLAG (Port-Channel Configuration)
-  eos_template:
-    src: base_po.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: mlag is defined
-
-- name: Arista MLAG (Mlag Configuration)
-  eos_template:
-    src: base_mlag.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: mlag is defined
-
-- name: Arista MLAG (Peer Link Configuration)
-  eos_template:
-    src: peer_links.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  with_items: '{{ mlag.peer_link_members | default([]) }}'
-  when: mlag is defined
+# Import the resource tasks based on the version of ansible in use
+- name: Include the Arista EOS MLAG resources
+  include: "tasks/resources{{ resource_version }}.yml"

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -1,0 +1,71 @@
+# Perform the EOS MLAG tasks under Ansible 2.1 or earlier
+# using the Ansible eos_template module
+
+- name: Arista MLAG (Vlan Configuration) (Ansible <= 2.1)
+  eos_template:
+    src: base_vlan.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: mlag is defined
+
+- name: Arista MLAG (Port-Channel Configuration) (Ansible <= 2.1)
+  eos_template:
+    src: base_po.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: mlag is defined
+
+- name: Arista MLAG (Mlag Configuration) (Ansible <= 2.1)
+  eos_template:
+    src: base_mlag.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: mlag is defined
+
+- name: Arista MLAG (Peer Link Configuration) (Ansible <= 2.1)
+  eos_template:
+    src: peer_links.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  with_items: '{{ mlag.peer_link_members | default([]) }}'
+  when: mlag is defined

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -1,0 +1,73 @@
+# Perform the EOS MLAG tasks under Ansible 2.2 or later
+# using the Ansible eos_config module
+
+- name: Arista MLAG (Vlan Configuration) (Ansible >= 2.2)
+  eos_config:
+    src: base_vlan.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: mlag is defined
+
+- name: Arista MLAG (Port-Channel Configuration) (Ansible >= 2.2)
+  eos_config:
+    src: base_po.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: mlag is defined
+
+- name: Arista MLAG (Mlag Configuration) (Ansible >= 2.2)
+  eos_config:
+    src: base_mlag.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: mlag is defined
+
+- name: Arista MLAG (Peer Link Configuration) (Ansible >= 2.2)
+  eos_config:
+    src: peer_links.j2
+    # src: source_test.j2
+    match: 'none'
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  with_items: '{{ mlag.peer_link_members | default([]) }}'
+  when: mlag is defined

--- a/test/testcases/mlag.yml
+++ b/test/testcases/mlag.yml
@@ -230,7 +230,7 @@ testcases:
       interface Ethernet3
       no shutdown
       switchport
-      switchport mode access
+      switchport mode trunk
       switchport trunk native vlan 1
       switchport trunk allowed vlan 1-4094
       switchport access vlan 1
@@ -238,7 +238,7 @@ testcases:
       interface Ethernet4
       no shutdown
       switchport
-      switchport mode access
+      switchport mode trunk
       switchport trunk native vlan 1
       switchport trunk allowed vlan 1-4094
       switchport access vlan 1
@@ -253,7 +253,7 @@ testcases:
          no local-interface
          no peer-address
          no peer-link
-         reload-delay 0
+         no reload-delay
          no reload-delay non-mlag
          no reload-delay mode
          no shutdown
@@ -277,9 +277,7 @@ testcases:
       interface Port-Channel14
       mlag configuration
          domain-id mlag4
-         local-interface Vlan1027
          peer-address 14.0.0.4
-         peer-link Port-Channel14
       interface Ethernet3
          channel-group 14 mode active
       interface Ethernet4
@@ -392,8 +390,6 @@ testcases:
     absent: |
       mlag configuration
          domain-id mlag5a
-         local-interface Vlan2028
-         peer-address 115.0.0.4
          peer-link Port-Channel25
 
   - name: Configure disabled MLAG
@@ -481,7 +477,7 @@ testcases:
       interface Ethernet3
       no shutdown
       switchport
-      switchport mode access
+      switchport mode trunk
       switchport trunk native vlan 1
       switchport trunk allowed vlan 1-4094
       switchport access vlan 1
@@ -489,7 +485,7 @@ testcases:
       interface Ethernet4
       no shutdown
       switchport
-      switchport mode access
+      switchport mode trunk
       switchport trunk native vlan 1
       switchport trunk allowed vlan 1-4094
       switchport access vlan 1
@@ -504,7 +500,7 @@ testcases:
          no local-interface
          no peer-address
          no peer-link
-         reload-delay 0
+         no reload-delay
          no reload-delay non-mlag
          no reload-delay mode
          no shutdown
@@ -529,9 +525,7 @@ testcases:
     absent: |
       mlag configuration
          domain-id mlag7
-         local-interface Vlan1030
          peer-address 17.0.0.7
-         peer-link Port-Channel17
       vlan 1025-1032,2100-2102
          name MLAG-PEERING
          trunk group mlagpeergrp


### PR DESCRIPTION
Put tasks for eos_template and eos_config into separate resource
files, then import those task files into main according to the
version of Ansible being used.

Update test cases for changes in Ansible 2.2 and EOS